### PR TITLE
Add UFW to install script

### DIFF
--- a/itflow_install.sh
+++ b/itflow_install.sh
@@ -40,7 +40,7 @@ install_packages() {
     apt-get install -y apache2 mariadb-server \
     php libapache2-mod-php php-intl php-mysqli \
     php-curl php-imap php-mailparse libapache2-mod-md \
-    certbot python3-certbot-apache git sudo
+    certbot python3-certbot-apache git sudo ufw
 
     mariadb_secure_installation
 
@@ -57,6 +57,13 @@ modify_php_ini() {
 
     sed -i 's/^;\?upload_max_filesize =.*/upload_max_filesize = 500M/' $PHP_INI_PATH
     sed -i 's/^;\?post_max_size =.*/post_max_size = 500M/' $PHP_INI_PATH
+}
+
+setup_ufw() {
+    ufw allow https
+    ufw allow http
+    ufw allow ssh
+    ufw enable
 }
 
 setup_webroot() {
@@ -124,6 +131,8 @@ echo "#############################################"
 echo ""
 echo "Please follow the prompts to complete the installation."
 echo ""
+echo "Please note, UFW will be setup during the installation, restricting access to HTTP, HTTPS, and SSH."
+echo ""
 
 # Execution begins here
 check_root
@@ -136,6 +145,9 @@ install_packages
 
 echo -e "\n${GREEN}Step 3: Modifying PHP configurations...${NC}"
 modify_php_ini
+
+echo -e "\n${GREEN}Step 4. Setting up ufw"
+setup_ufw
 
 echo -e "\n${GREEN}Step 4: Setting up webroot...${NC}"
 setup_webroot


### PR DESCRIPTION
Added this because on some VPS providers (DigitalOcean for one), UFW is installed by default. This will accommodate for that variable, and make the default install a bit safer.